### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` (and the `.github/` directory) covering the `uv` and `github-actions` ecosystems, weekly.

Dev-dependency minor/patch bumps (pytest, pytest-cov, pytest-mock) are grouped into one PR per week. No runtime dependencies.

The `github-actions` entry is inert until this repo gains workflows — included so action bumps are covered from the moment CI is added.
🤖 Generated with [Claude Code](https://claude.com/claude-code)